### PR TITLE
fixed wrong Update Support for SAP Solutions abbreviation for RHEL 7.6

### DIFF
--- a/rhel-for-sap-configurator.js
+++ b/rhel-for-sap-configurator.js
@@ -298,7 +298,7 @@ function displayResults() {
             document.getElementById("idRHEL").innerHTML = "<a href=\"https://access.redhat.com/solutions/19458\"><b>gcc 4.8</b></a>. <a href=\"https://access.redhat.com/articles/3078#RHEL7\">Kernel Version: 3.10.0-862</a>. <a href=\"https://access.redhat.com/support/policy/updates/errata#Extended_Update_Support\">E4S not available; support for EUS ended April 30, 2020</a>";
          }
          else if (vRHEL == "7.6") {
-            _exs="e5s";
+            _exs="e4s";
             document.getElementById("idRemarks").innerHTML = "<a href=\"https://launchpad.support.sap.com/#/notes/2235581\">HANA 1.0 SPS12 rev 122.23 and newer</a>" + ".&nbsp;" +
 "<a href=\"https://launchpad.support.sap.com/#/notes/2021789\">Latest rev: HANA 1.0 SPS12 rev 122.35</a>." + "<br>" +
 "HANA 1.0 <b>SPS12</b>: gcc 4 ---&gt; <a href=\"https://launchpad.support.sap.com/#/notes/3057467\">No package compat-sap-c++-* required.</a><br>";


### PR DESCRIPTION
The repositories shown in [https://redhat-sap.github.io/rhel-for-sap-configurator/](https://redhat-sap.github.io/rhel-for-sap-configurator/) are incorrect for RHEL-7.6.

This PR should fix that issue.

~~~
Repositories:

rhel-7-server-e5s-rpms
rhel-sap-hana-for-rhel-7-server-e5s-rpms
rhel-ha-for-rhel-7-server-e5s-rpms
~~~